### PR TITLE
Feature/custom expiration dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Thunderbird extension that automatically manages emails with expiration dates 
 ## 🌟 Features
 
 - ✅ **Automatic Detection**: Identifies emails with "Expires" headers
+- 🔧 **Custom Expiration Dates**: No expiration date set? Just add your own!
 - 🗑️ **Flexible Actions**: Choose to delete or move expired emails
 - 🔄 **Multiple Check Options**: Manual, startup, or periodic checks
 - 🎯 **Folder Selection**: Check all folders or select specific ones
@@ -95,6 +96,12 @@ Test the extension without making changes:
 email-expiration-manager/
 ├── manifest.json              # Extension manifest
 ├── background.js              # Core logic and message handling
+├── date_picker/
+│   ├── date_picker.html      # Date selection popup HTML
+│   ├── date_picker.js        # Popup logic
+│   └── date_picker.css       # Popup styles
+├── modules/
+│   ├── custom_expiration.js  # Common code for user-selected expiration date
 ├── options/
 │   ├── options.html          # Settings page HTML
 │   ├── options.js            # Settings page logic
@@ -128,6 +135,7 @@ email-expiration-manager/
 - **browser.notifications**: Display notifications
 - **browser.alarms**: Schedule periodic checks
 - **browser.i18n**: Internationalization
+- **browser.messages.tags**: Implement custom expiration date through tags
 
 ### Adding New Languages
 
@@ -157,9 +165,17 @@ email-expiration-manager/
 - Triggers manual checks
 - Shows check results
 
+#### date_picker.js
+- Date selection logic
+- Displays current selected date
+- Allows to pick any date
+
+#### custom_expiration.js
+- Common code for tagging the emails
+
 ## 🔍 How It Works
 
-1. **Email Detection**: The extension scans emails for the "Expires" header
+1. **Email Detection**: The extension scans emails for the "Expires" header or for its own date tags
 2. **Date Parsing**: Parses RFC 5322 date format (e.g., "Tue, 20 Aug 2024 14:18:31 -0000")
 3. **Expiration Check**: Compares the expiration date with the current date
 4. **Action**: If expired:
@@ -173,9 +189,13 @@ email-expiration-manager/
 - `messagesRead`: Read email content and headers
 - `messagesMove`: Move emails to folders
 - `messagesDelete`: Delete expired emails
+- `messagesUpdate`: Set expiration date on messages by tagging them
+- `messagesTags`: Create and delete tags
+- `messagesTagsList`: List existing tags to reuse them if applicable
 - `storage`: Save settings and logs
 - `notifications`: Display completion notifications
 - `alarms`: Schedule periodic checks
+- `menus`: Add action to context menu
 
 ## 🐛 Debugging
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -360,5 +360,51 @@
   "aboutDevelopedBy": {
     "message": "Developed by:",
     "description": "Developed by label"
+  },
+  "setExpiryDate": {
+    "message": "Set expiration date",
+    "description": "Action text to force an expiration date"
+  },
+  "saveDate": {
+    "message": "Save",
+    "description": "Button to save the date"
+  },
+  "cancelDate": {
+    "message": "Cancel",
+    "description": "Button to close the date selection popup"
+  },
+  "captionDate": {
+    "message": "Pick the expiration date:",
+    "description": "Label for the date selection popup"
+  },
+  "noneDate": {
+    "message": "None",
+    "description": "No expiration"
+  },
+  "oneDayDate": {
+    "message": "1 day",
+    "description": "Expiration in 1 day"
+  },
+  "oneWeekDate": {
+    "message": "1 week",
+    "description": "Expiration in 1 week"
+  },
+  "oneMonthDate": {
+    "message": "1 month",
+    "description": "Expiration in 1 month"
+  },
+  "customDate": {
+    "message": "Custom:",
+    "description": "Expiration at a user-selected date"
+  },
+  "expiryTag": {
+    "message": "Expires on $1",
+    "description": "Text for the message tag label",
+    "placeholders": {
+      "1": {
+        "content": "$1",
+        "example": "2026/01/04"
+      }
+    }
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -360,5 +360,51 @@
   "aboutDevelopedBy": {
     "message": "Développé par :",
     "description": "Label développé par"
+  },
+  "setExpiryDate": {
+    "message": "Fixer la date d'expiration",
+    "description": "Texte de l'action pour forcer une date d'expiration"
+  },
+  "saveDate": {
+    "message": "Enregistrer",
+    "description": "Bouton pour enregistrer la date"
+  },
+  "cancelDate": {
+    "message": "Annuler",
+    "description": "Bouton pour fermer la popup de choix de date"
+  },
+  "captionDate": {
+    "message": "Choisir la date d'expiration :",
+    "description": "Label de la popup de choix de date"
+  },
+  "noneDate": {
+    "message": "Aucune",
+    "description": "Pas d'expiration"
+  },
+  "oneDayDate": {
+    "message": "1 jour",
+    "description": "Expiration dans 1 jour"
+  },
+  "oneWeekDate": {
+    "message": "1 semaine",
+    "description": "Expiration dans 1 semaine"
+  },
+  "oneMonthDate": {
+    "message": "1 mois",
+    "description": "Expiration dans 1 mois"
+  },
+  "customDate": {
+    "message": "Personnalisée :",
+    "description": "Expiration à une date choisie par l'utilisateur"
+  },
+  "expiryTag": {
+    "message": "Expire le $1",
+    "description": "Texte pour l'étiquette de message",
+    "placeholders": {
+      "1": {
+        "content": "$1",
+        "example": "04/01/2026"
+      }
+    }
   }
 }

--- a/background.js
+++ b/background.js
@@ -20,6 +20,7 @@
  * Email Expiration Manager - Background Script
  * Handles all core functionality for checking and managing expired emails
  */
+import { TAG_PREFIX, updateMessageTags } from "./modules/custom_expiration.js"
 
 // Default settings
 const DEFAULT_SETTINGS = {
@@ -39,6 +40,24 @@ const DEFAULT_SETTINGS = {
 
 // Storage for logs
 let actionLogs = [];
+let selectedMessages = null;
+
+const MENU_ITEM_ID = "menu_setExpiryDate";
+
+/**
+ * Handle the menu item to set expiration date from the mail folder view
+ */
+browser.menus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId === MENU_ITEM_ID) {
+    selectedMessages = info.selectedMessages;
+    await browser.windows.create({
+        url: "date_picker/date_picker.html?source=menu",
+        type: "popup",
+        width: 420,
+        height: 370
+    });
+  }
+});
 
 /**
  * Initialize extension on install/update
@@ -57,6 +76,13 @@ browser.runtime.onInstalled.addListener(async (details) => {
   if (!logs.logs) {
     await browser.storage.local.set({ logs: [] });
   }
+  
+  // Add menu entry to override or set custom expiration date
+  await addEntry({
+    id: MENU_ITEM_ID,
+    title: browser.i18n.getMessage("setExpiryDate"),
+    contexts: ["message_list"]
+  });
 });
 
 /**
@@ -121,6 +147,15 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
       browser.alarms.clear('periodicCheck');
     }
     return { success: true };
+  } else if (message.type === "popup-data") {
+    const date = message.value;
+    if (selectedMessages) {
+      updateMessageTags(date, selectedMessages.messages);
+      while (selectedMessages.id) {
+        selectedMessages = await messenger.messages.continueList(selectedMessages.id);
+        updateMessageTags(date, selectedMessages.messages);
+      }
+    }
   }
 });
 
@@ -300,7 +335,16 @@ async function checkExpiredEmails(settings) {
             
             // Look for Expires header
             const headers = fullMessage.headers;
-            const expiresHeader = headers.expires ? headers.expires[0] : null;
+            let expiresHeader = headers.expires ? headers.expires[0] : null;
+            
+            const header = await browser.messages.get(message.id);
+            // Parse all tags if any, there should be at most one, parse date as Date
+            // If there are 2 dates set, the tag gets priority even if it is after the Expires: date
+            const eemTags = header.tags.filter(t => t.startsWith(TAG_PREFIX));
+            if (eemTags.length > 0){
+              expiresHeader = eemTags[0].substring(TAG_PREFIX.length);
+              console.log(`Using user-selected expiration date for message ${message.id}: ${expiresHeader}`);
+            }
             
             if (expiresHeader) {
               console.log(`Found Expires header in message ${message.id}: ${expiresHeader}`);
@@ -349,6 +393,23 @@ async function checkExpiredEmails(settings) {
         errors.push(`Error in folder ${folder.path}: ${err.message}`);
       }
     }
+    
+    // Tag cleanup
+    console.log('Cleaning up expiration tags');
+    let referenceDate = new Date().toISOString().substring(0, 10);
+    let existingTags = await browser.messages.tags.list();
+    existingTags.map(item => item.key)
+      .filter(key => key.startsWith(TAG_PREFIX))
+      .map(key => key.substring(TAG_PREFIX.length))
+      .filter(key => key <= referenceDate)
+      .forEach((key) => {
+        if (!settings.dryRun) {
+          browser.messages.tags.delete(key);
+          console.log(`Deleted tag ${key}`);
+        } else {
+          console.log(`DRY RUN: Would delete tag ${key}`);
+        }
+      });
     
     console.log('=== Check complete ===');
     console.log(`Total checked: ${totalChecked}`);
@@ -428,6 +489,35 @@ async function addLog(logEntry) {
   const updatedLogs = [logEntry, ...currentLogs].slice(0, 100);
   
   await browser.storage.local.set({ logs: updatedLogs });
+}
+
+/**
+ * Add a menu entry
+ */
+async function addEntry(createData) {
+  let { promise, resolve, reject } = Promise.withResolvers();
+  let error;
+  let id = browser.menus.create(createData, () => { 
+    error = browser.runtime.lastError; // Either null or an Error object.
+    if (error) {
+      reject(error)
+    } else {
+      resolve();
+    }
+  });
+
+  try {
+    await promise;
+    console.info(`Successfully created menu entry <${id}>`);
+  } catch (error) {
+    if (error.message.includes("already exists")) {
+      console.info(`The menu entry <${id}> exists already and was not added again.`);
+    } else {
+      console.error("Failed to create menu entry:", createData, error);
+    }
+  }
+
+  return id;
 }
 
 console.log('Email Expiration Manager background script loaded');

--- a/date_picker/date_picker.css
+++ b/date_picker/date_picker.css
@@ -1,0 +1,105 @@
+/**
+ * Email Expiration Manager - Thunderbird Extension
+ * Copyright (C) 2025 Mindbaz / Pierre-Yves Dubreucq
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Popup styles
+ */
+
+:root {
+  --primary-color: #0a84ff;
+  --success-color: #12bc00;
+  --danger-color: #d70022;
+  --border-color: #d7d7db;
+  --bg-color: #ffffff;
+  --bg-secondary: #f9f9fa;
+  --text-primary: #0c0c0d;
+  --text-secondary: #737373;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  width: 350px;
+  background-color: var(--bg-color);
+}
+
+.popup-container {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  background-color: var(--primary-color);
+  color: white;
+  padding: 15px;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+main {
+  padding: 15px;
+}
+
+.action-section {
+  margin-bottom: 20px;
+  margin-top: 5px;
+}
+
+.button {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.button-primary {
+  background-color: var(--primary-color);
+  color: white;
+}
+
+.button-primary:hover:not(:disabled) {
+  background-color: #0060df;
+}
+
+.button-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.results-container {
+  margin-top: 15px;
+  padding: 15px;
+  background-color: var(--bg-secondary);
+  border-radius: 4px;
+}

--- a/date_picker/date_picker.html
+++ b/date_picker/date_picker.html
@@ -1,0 +1,68 @@
+<!--
+  Email Expiration Manager - Thunderbird Extension
+  Copyright (C) 2025 Mindbaz / Pierre-Yves Dubreucq
+  
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title data-i18n="extensionName">Email Expiration Manager</title>
+  <link rel="stylesheet" href="date_picker.css">
+</head>
+<body>
+  <div class="popup-container">
+    <header>
+      <h1 data-i18n="extensionName">Email Expiration Manager</h1>
+    </header>
+
+    <main>
+      <p data-i18n="captionDate">Pick the expiration date:</p>
+      <div>
+        <input type="radio" id="none" value="0" name="selectedDate" />
+        <label for="none" data-i18n="noneDate">None</label>
+      </div>
+      <div>
+        <input type="radio" id="1day" value="1" name="selectedDate" />
+        <label for="1day" data-i18n="oneDayDate">1 day</label>
+      </div>
+      <div>
+        <input type="radio" id="1week" value="7" name="selectedDate" />
+        <label for="1week" data-i18n="oneWeekDate">1 week</label>
+      </div>
+      <div>
+        <input type="radio" id="1month" value="30" name="selectedDate" />
+        <label for="1month" data-i18n="oneMonthDate">1 month</label>
+      </div>
+      <div>
+        <input type="radio" id="custom" value="0" name="selectedDate" checked="true" />
+        <label for="custom" data-i18n="customDate">Custom: </label>
+        <input type="date" id="selectedDate" name="expiration" />
+      </div>
+      <div class="action-section">
+        <button id="save" class="button button-primary" data-i18n="saveDate">
+          Save
+        </button>
+        <button id="cancel" class="button" data-i18n="cancelDate">
+          Cancel
+        </button>
+      </div>
+    </main>
+  </div>
+
+  <script src="date_picker.js" type="module"></script>
+</body>
+</html>

--- a/date_picker/date_picker.js
+++ b/date_picker/date_picker.js
@@ -1,0 +1,137 @@
+/**
+ * Email Expiration Manager - Thunderbird Extension
+ * Copyright (C) 2025 Mindbaz / Pierre-Yves Dubreucq
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Popup script
+ * Provides date selection to set a custom expiry date
+ */
+import { TAG_PREFIX, updateMessageTags } from "../modules/custom_expiration.js"
+
+const elements = {
+  dateValue: document.getElementById('selectedDate'),
+  saveButton: document.getElementById('save'),
+  cancelButton: document.getElementById('cancel'),
+  noneRadio: document.getElementById('none'),
+  oneDayRadio: document.getElementById('1day'),
+  oneWeekRadio: document.getElementById('1week'),
+  oneMonthRadio: document.getElementById('1month'),
+  customDateRadio: document.getElementById('custom')
+};
+let currentMessage = null;
+let source = null;
+
+/**
+ * Localize all UI elements
+ */
+function localizeUI() {
+  document.querySelectorAll('[data-i18n]').forEach(element => {
+    const message = browser.i18n.getMessage(element.getAttribute('data-i18n'));
+    if (message) {
+      element.textContent = message;
+    }
+  });
+}
+
+/**
+ * Save selected date
+ */
+async function save(e) {
+  let date = new Date();
+  if (elements.oneDayRadio.checked) {
+    date.setDate(date.getDate() + 1);
+  } else if (elements.oneWeekRadio.checked) {
+    date.setDate(date.getDate() + 7);
+  } else if (elements.oneMonthRadio.checked) {
+    date.setMonth(date.getMonth() + 1);
+  } else if (elements.customDateRadio.checked) {
+    date = new Date(elements.dateValue.value);
+  } else if (elements.noneRadio.checked) {
+    date = null;
+  }
+
+  if (currentMessage) {
+    await updateMessageTags(date, [currentMessage]);
+  } else {
+    // Just send data to background script
+    await browser.runtime.sendMessage({
+      type: "popup-data",
+      value: date
+    });
+  }
+  
+  currentMessage = null;
+
+  window.close();
+}
+
+/**
+ * Close popup
+ */
+function cancel(e) {
+  e.preventDefault();
+  window.close();
+}
+
+/**
+ * Initialize popup
+ */
+async function init() {
+  localizeUI();
+
+  elements.dateValue.value = new Date().toISOString().substring(0, 10);
+  
+  // Event listeners
+  elements.saveButton.addEventListener('click', save);
+  elements.cancelButton.addEventListener('click', cancel);
+  
+  // Find out how we have been called to adjust behavior
+  const params = new URLSearchParams(window.location.search);
+  source = params.get("source");
+  console.log(`Opened from: ${source}`);
+
+  if (source === "action") {
+    // Only find the message if we are being triggered from an action
+    browser.tabs.query({
+      active: true,
+      currentWindow: true,
+    }).then(tabs => {
+      let tabId = tabs[0].id;
+      browser.messageDisplay.getDisplayedMessage(tabId).then((message) => {
+        console.log(`Opening popup for message ${message.id}`);
+        currentMessage = message;
+        // Get tags from message, find ours and set date with detected date, check correct radio in this case
+        let tags = message.tags;
+        let expirationTag = tags.filter(item => item.startsWith(TAG_PREFIX));
+        if (expirationTag.length > 0) {
+          console.log(`Found tag ${expirationTag[0]}`);
+          const tagDate = expirationTag[0].substring(TAG_PREFIX.length);
+          elements.dateValue.value = tagDate;
+          elements.customDateRadio.checked = true;
+        }
+      });
+    });
+  }
+}
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -26,13 +26,18 @@
     "messagesRead",
     "messagesMove",
     "messagesDelete",
+    "messagesUpdate",
+    "messagesTags",
+    "messagesTagsList",
     "storage",
     "notifications",
-    "alarms"
+    "alarms",
+    "menus"
   ],
 
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "type": "module"
   },
 
   "options_ui": {
@@ -47,5 +52,24 @@
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png"
     }
+  },
+
+  "compose_action": {
+    "default_title": "__MSG_setExpiryDate__",
+    "default_popup": "date_picker/date_picker.html?source=action",
+    "default_icon": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png"
+    }
+  },
+
+  "message_display_action": {
+    "default_title": "__MSG_setExpiryDate__",
+    "default_popup": "date_picker/date_picker.html?source=action",
+    "default_icon": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png"
+    }
   }
+
 }

--- a/modules/custom_expiration.js
+++ b/modules/custom_expiration.js
@@ -1,0 +1,58 @@
+/**
+ * Email Expiration Manager - Thunderbird Extension
+ * Copyright (C) 2025 Mindbaz / Pierre-Yves Dubreucq
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Module
+ * Factors the common logic to set a custom expiry date
+ */
+
+export const TAG_PREFIX = "eem:expires:";
+
+/**
+ * Update messages expiration dates
+ */
+export async function updateMessageTags(date, currentMessages) {
+  let key = null;
+  // Write the date as a tag to the current message being processed
+  if (date) {
+    const tagName = TAG_PREFIX + date.toISOString().substring(0, 10);
+
+    let existingTags = await browser.messages.tags.list();
+    let existingTag = existingTags.filter(tag => tag.key === tagName);
+    if (existingTag.length === 0) {
+      // Create the tag if it does not exist
+      key = await browser.messages.tags.create(tagName,
+            browser.i18n.getMessage('expiryTag', [date.toLocaleDateString()]),
+            "#000000");
+    } else {
+      // Use existing
+      key = existingTag[0].key;
+    }
+  }
+
+  // Write the tag to the messages, overwriting any existing tag set by this extension
+  // If the key is null, it means that we want to remove the expiration date
+  for (const currentMessage of currentMessages) {
+    let newTags = Array.from(currentMessage.tags.filter(tag => !tag.startsWith(TAG_PREFIX)));
+    if (key) {
+      newTags.push(key);
+    }
+    browser.messages.update(currentMessage.id, { tags : newTags });
+    console.log(`Marked message ${currentMessage.id}`);
+  }
+}


### PR DESCRIPTION
## Description
This PR aims to bring the ability for the end user to set their own expiration date, since the `Expires` header is not very common for the moment. This feature is achieved through the use of tags.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement

## Testing
- [X] Tested in dry run mode
- [X] Tested with real emails
- [X] No console errors
- [X] Works on: Linux / Windows / macOS

## Related Issues
Fixes #1 

## Checklist
- [X] Code follows project style guidelines
- [x] Comments are in English
- [X] Tested thoroughly
- [X] Documentation updated (if needed)
- [x] I agree to license my contributions under GPLv3