### PR TITLE
Per-mailbox action configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Thunderbird extension that automatically manages emails with expiration dates 
 ## 🌟 Features
 
 - ✅ **Automatic Detection**: Identifies emails with "Expires" headers
-- 🗑️ **Flexible Actions**: Choose to delete or move expired emails
+- 🗑️ **Flexible Actions**: Choose to delete or move expired emails, the action can be set on a per-mailbox basis if needed
 - 🔄 **Multiple Check Options**: Manual, startup, or periodic checks
 - 🎯 **Folder Selection**: Check all folders or select specific ones
 - 🧪 **Dry Run Mode**: Test without making changes

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -55,6 +55,10 @@
     "message": "Action Settings",
     "description": "Section title for action settings"
   },
+  "actionSettingsDesc": {
+    "message": "This action will become the default one, it can be overridden on a per-account basis below.",
+    "description": "Section description for action settings"
+  },
   "actionLabel": {
     "message": "Action for expired emails:",
     "description": "Label for action selection"
@@ -66,6 +70,10 @@
   "actionMove": {
     "message": "Move to folder",
     "description": "Option to move expired emails"
+  },
+  "actionDefault": {
+    "message": "Default",
+    "description": "Option to follow the extension default action"
   },
   "permanentDelete": {
     "message": "Permanent deletion (skip trash)",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -55,6 +55,10 @@
     "message": "Paramètres d'Action",
     "description": "Titre de section pour les paramètres d'action"
   },
+  "actionSettingsDesc": {
+    "message": "Cette action deviendra l'action par défaut, elle peut être redéfinie par compte ci-dessous.",
+    "description": "Description de section pour les paramètres d'action"
+  },
   "actionLabel": {
     "message": "Action pour les e-mails expirés :",
     "description": "Label pour la sélection d'action"
@@ -66,6 +70,10 @@
   "actionMove": {
     "message": "Déplacer vers un dossier",
     "description": "Option pour déplacer les e-mails expirés"
+  },
+  "actionDefault": {
+    "message": "Défaut",
+    "description": "Option pour suivre l'action par défaut de l'extension"
   },
   "permanentDelete": {
     "message": "Suppression définitive (sans corbeille)",

--- a/background.js
+++ b/background.js
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS = {
   dryRun: false,
   selectedAccounts: [], // empty means all accounts
   selectedFolders: [], // empty means all folders
+  perMailboxActions: new Map(),
   logActions: true
 };
 
@@ -229,6 +230,43 @@ async function findFolderById(folderId) {
 }
 
 /**
+ * Find the account for a given folder by ID
+ * Returns the account ID
+ */
+async function findAccountForFolderById(folderId) {
+  if (!folderId) return null;
+  
+  const accounts = await browser.accounts.list();
+  
+  for (const account of accounts) {
+    const folders = await getAllFolders(account);
+    // Match by id or path for backwards compatibility
+    const found = folders.find(f => f.id === folderId || f.path === folderId);
+    if (found) {
+      return account.id;
+    }
+  }
+  
+  return null;
+}
+
+/*
+ * Check target folder for existence
+ */
+async function checkTargetFolder(action, folder) {
+  let targetFolderObj = null;
+  if (action === 'move' && folder) {
+    targetFolderObj = await findFolderById(folder);
+    if (!targetFolderObj) {
+      console.error(`Target folder not found: ${folder}`);
+    } else {
+      console.log(`Target folder found: ${targetFolderObj.path}`);
+    }
+  }
+  return targetFolderObj;
+}
+
+/**
  * Main function to check for expired emails
  * UPDATED: Fixed pagination bug and added detailed logging
  */
@@ -244,20 +282,15 @@ async function checkExpiredEmails(settings) {
   console.log('Dry run mode:', settings.dryRun);
   
   // Get the target folder object if action is 'move'
-  let targetFolderObj = null;
-  if (settings.action === 'move' && settings.targetFolder) {
-    targetFolderObj = await findFolderById(settings.targetFolder);
-    if (!targetFolderObj) {
-      console.error(`Target folder not found: ${settings.targetFolder}`);
-      return {
-        success: false,
-        error: `Target folder not found: ${settings.targetFolder}`,
-        totalChecked: 0,
-        totalExpired: 0,
-        totalProcessed: 0
-      };
-    }
-    console.log('Target folder found:', targetFolderObj.path);
+  let targetFolderObj = await checkTargetFolder(settings.action, settings.targetFolder);
+  if (settings.action === 'move' && settings.targetFolder && !targetFolderObj) {
+    return {
+      success: false,
+      error: `Target folder not found: ${settings.targetFolder}`,
+      totalChecked: 0,
+      totalExpired: 0,
+      totalProcessed: 0
+    };
   }
   
   try {
@@ -269,7 +302,23 @@ async function checkExpiredEmails(settings) {
     }
     
     for (const folder of folders) {
+      let action = settings.action;
+      let targetFolder = targetFolderObj;
+      
+      const parentAccount = await findAccountForFolderById(folder.id);
+      if (parentAccount && settings.perMailboxActions.has(parentAccount) && settings.perMailboxActions.get(parentAccount).action !== 'default') {
+        // Only override action configuration for folder if actually possible and necessary
+        action = settings.perMailboxActions.get(parentAccount).action;
+        targetFolder = await checkTargetFolder(action, settings.perMailboxActions.get(parentAccount).folder);
+        if (action === 'move' && settings.perMailboxActions.get(parentAccount).folder && !targetFolder) {
+          // Skip the folder if move is not possible
+          console.log(`Destination folder for folder ${folder.path} not found, skipping this folder`);
+          continue;
+        }
+      }
+      
       console.log(`Checking folder: ${folder.path}`);
+      console.log(`Action: ${action}, target folder (if move): ${targetFolder}`);
       
       try {
         // Get messages from folder
@@ -313,20 +362,20 @@ async function checkExpiredEmails(settings) {
                 // Process the expired email
                 if (!settings.dryRun) {
                   try {
-                    if (settings.action === 'delete') {
+                    if (action === 'delete') {
                       const deleteMode = settings.permanentDelete ? 'permanently' : 'to trash';
                       console.log(`Deleting message ${message.id} ${deleteMode}`);
                       // Use boolean for compatibility with current Thunderbird versions
                       // false = move to trash, true = permanent deletion
                       await browser.messages.delete([message.id], settings.permanentDelete);
                       totalProcessed++;
-                    } else if (settings.action === 'move' && targetFolderObj) {
-                      console.log(`Moving message ${message.id} to ${targetFolderObj.path}`);
+                    } else if (action === 'move' && targetFolder) {
+                      console.log(`Moving message ${message.id} to ${targetFolder.path}`);
                       // Use the folder object directly for the move operation
-                      await browser.messages.move([message.id], targetFolderObj);
+                      await browser.messages.move([message.id], targetFolder);
                       totalProcessed++;
                     } else {
-                      console.warn(`Cannot process message ${message.id}: action=${settings.action}, targetFolder=${settings.targetFolder}`);
+                      console.warn(`Cannot process message ${message.id}: action=${action}, targetFolder=${targetFolder.path}`);
                     }
                   } catch (err) {
                     console.error(`Failed to process message ${message.id}:`, err);

--- a/options/options.css
+++ b/options/options.css
@@ -102,6 +102,16 @@ main {
   cursor: pointer;
 }
 
+input[type="radio"] {
+  margin-left: 5px;
+  margin-right: 3px;
+}
+
+select {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
 .setting-description {
   color: var(--text-secondary);
   font-size: 13px;

--- a/options/options.html
+++ b/options/options.html
@@ -54,6 +54,8 @@
       <section class="settings-section">
         <h2 data-i18n="actionSettings">Action Settings</h2>
         
+        <p class="setting-description" data-i18n="actionSettingsDesc">This action will become the default one, it can be overridden on a per-account basis below.</p>
+        
         <div class="setting-item">
           <label for="action" data-i18n="actionLabel">Action for expired emails:</label>
           <select id="action" class="select-input">

--- a/options/options.js
+++ b/options/options.js
@@ -54,6 +54,7 @@ let allAccounts = [];
 let allFolders = [];
 let selectedAccounts = [];
 let selectedFolders = [];
+let perMailboxActions = new Map();
 
 /**
  * Localize all UI elements
@@ -108,27 +109,97 @@ async function populateAccountList() {
     checkbox.value = account.id;
     checkbox.checked = selectedAccounts.includes(account.id);
     
-    checkbox.addEventListener('change', async (e) => {
-      if (e.target.checked) {
-        selectedAccounts.push(account.id);
-      } else {
-        selectedAccounts = selectedAccounts.filter(id => id !== account.id);
-      }
-      // Refresh folder list when account selection changes
-      await populateFolderList();
-    });
-    
     const label = document.createElement('label');
     label.htmlFor = `account-${account.id}`;
     label.textContent = account.name;
     
+    item.appendChild(checkbox);
+    item.appendChild(label);
+    
+    // Create radio buttons
+    const options = [
+      { label: browser.i18n.getMessage('actionDefault'), value: 'default' },
+      { label: browser.i18n.getMessage('actionDelete'), value: 'delete' },
+      { label: browser.i18n.getMessage('actionMove'), value: 'move' }
+    ];
+
+    options.forEach(opt => {
+      const wrapper = document.createElement('div');
+
+      const radio = document.createElement('input');
+      radio.type = 'radio';
+      radio.name = `actionType-account-${account.id}`;   // same group
+      radio.value = opt.value;
+      radio.checked = perMailboxActions.has(account.id) && perMailboxActions.get(account.id).action === opt.value;
+      opt.ui = radio;
+
+      const label = document.createElement('label');
+      label.textContent = opt.label;
+
+      wrapper.appendChild(radio);
+      wrapper.appendChild(label);
+      item.appendChild(wrapper);
+    });
+
+    // Create dropdown
+    const dropdown = document.createElement('select');
+    dropdown.id = `folderList-account-${account.id}`;
+    
+    const option0 = document.createElement('option');
+    option0.value = '';
+    option0.textContent = browser.i18n.getMessage('selectFolder');
+    dropdown.appendChild(option0);
+    
+    // Populate it solely with folders for the current account
+    const folders = await getAllFolders(account);
+    for (const folder of folders) {
+      const option = document.createElement('option');
+      // Store the folder ID instead of path for proper API usage
+      option.value = folder.id;
+      option.setAttribute('data-path', folder.path);
+      option.textContent = '  '.repeat(folder.depth) + folder.name;
+      dropdown.appendChild(option);
+    }
+    dropdown.value = perMailboxActions.has(account.id) && perMailboxActions.get(account.id).folder ? perMailboxActions.get(account.id).folder : '';
+    
+    const radios = options.map((opt) => opt.ui);
+    
+    dropdown.addEventListener('change', () => {
+        perMailboxActions.getOrInsert(account.id, {}).folder = dropdown.value;
+    });
+
+    // Enable/disable everything when checkbox changes
+    checkbox.addEventListener('change', async (e) => {
+      const enabled = e.target.checked;
+      if (enabled) {
+        selectedAccounts.push(account.id);
+      } else {
+        selectedAccounts = selectedAccounts.filter(id => id !== account.id);
+      }
+      
+      radios.forEach(r => r.disabled = !enabled);
+      
+      dropdown.disabled = !(enabled && document.querySelector(`input[name='actionType-account-${account.id}']:checked`)?.value === 'move');
+      
+      // Refresh folder list when account selection changes
+      await populateFolderList();
+    });
+
+    // Radio button logic: dropdown enabled only when "move" is selected
+    radios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        dropdown.disabled = radio.value !== 'move';
+        perMailboxActions.getOrInsert(account.id, {}).action = radio.value;
+      });
+    });
+
     const accountType = document.createElement('span');
     accountType.className = 'account-type';
     accountType.textContent = account.type;
     
-    item.appendChild(checkbox);
-    item.appendChild(label);
+    item.appendChild(dropdown);
     item.appendChild(accountType);
+    
     elements.accountList.appendChild(item);
   }
 }
@@ -190,11 +261,18 @@ async function getAllFolders(account) {
  * Populate target folder dropdown
  */
 async function populateTargetFolders() {
+    populateTargetFoldersFor(elements.targetFolder);
+}
+
+/**
+ * Populate a target folder dropdown
+ */
+async function populateTargetFoldersFor(dropdown) {
   const folders = await loadFolders();
   
   // Clear existing options except the first one
-  while (elements.targetFolder.options.length > 1) {
-    elements.targetFolder.remove(1);
+  while (dropdown.options.length > 1) {
+    dropdown.remove(1);
   }
   
   for (const folder of folders) {
@@ -203,7 +281,7 @@ async function populateTargetFolders() {
     option.value = folder.id;
     option.setAttribute('data-path', folder.path);
     option.textContent = '  '.repeat(folder.depth) + folder.name;
-    elements.targetFolder.appendChild(option);
+    dropdown.appendChild(option);
   }
 }
 
@@ -368,6 +446,7 @@ async function loadSettings() {
     elements.logActions.checked = settings.logActions !== undefined ? settings.logActions : true;
     selectedAccounts = settings.selectedAccounts || [];
     selectedFolders = settings.selectedFolders || [];
+    perMailboxActions = settings.perMailboxActions || new Map();
   }
   
   updateUIState();
@@ -389,7 +468,8 @@ async function saveSettings() {
     showNotifications: elements.showNotifications.checked,
     logActions: elements.logActions.checked,
     selectedAccounts: selectedAccounts,
-    selectedFolders: selectedFolders
+    selectedFolders: selectedFolders,
+    perMailboxActions: perMailboxActions
   };
   
   await browser.storage.local.set({ settings });


### PR DESCRIPTION
## Description
In addition to the current action setting, allow the user to select a different action or a different folder for each mailbox. 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement

## Testing
- [X] Tested in dry run mode
- [X] Tested with real emails
- [X] No console errors
- [X] Works on: Linux / Windows / macOS


## Related Issues
Fixes #2 

## Checklist
- [X] Code follows project style guidelines
- [X] Comments are in English
- [X] Tested thoroughly
- [X] Documentation updated (if needed)
- [X] I agree to license my contributions under GPLv3